### PR TITLE
Translate account page and create missing translations

### DIFF
--- a/apps/mobile/app/(tabs)/account/_layout.tsx
+++ b/apps/mobile/app/(tabs)/account/_layout.tsx
@@ -1,6 +1,18 @@
 import { Stack } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import {
+  NAMESPACES,
+  NavigationTranslations,
+  AccountTranslations,
+  SecurityTranslations,
+  PreferencesTranslations,
+  DangerTranslations,
+} from '@/i18n/constants';
 
 export default function AccountStackLayout() {
+  const { t } = useTranslation(NAMESPACES.ACCOUNT);
+  const { t: tNav } = useTranslation(NAMESPACES.NAVIGATION);
+
   return (
     <Stack
       screenOptions={{
@@ -9,14 +21,14 @@ export default function AccountStackLayout() {
         contentStyle: { backgroundColor: 'transparent' },
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false, headerBackTitle: 'Return' }} />
-      <Stack.Screen name="account" options={{ title: 'Account', headerBackTitle: 'Return' }} />
-      <Stack.Screen name="security" options={{ title: 'Security', headerBackTitle: 'Return' }} />
+      <Stack.Screen name="index" options={{ headerShown: false, headerBackTitle: tNav(NavigationTranslations.BACK) }} />
+      <Stack.Screen name="account" options={{ title: t(AccountTranslations.TITLE), headerBackTitle: tNav(NavigationTranslations.BACK) }} />
+      <Stack.Screen name="security" options={{ title: t(SecurityTranslations.TITLE), headerBackTitle: tNav(NavigationTranslations.BACK) }} />
       <Stack.Screen
         name="preferences"
-        options={{ title: 'Preferences', headerBackTitle: 'Return' }}
+        options={{ title: t(PreferencesTranslations.TITLE), headerBackTitle: tNav(NavigationTranslations.BACK) }}
       />
-      <Stack.Screen name="danger" options={{ title: 'Danger Zone', headerBackTitle: 'Return' }} />
+      <Stack.Screen name="danger" options={{ title: t(DangerTranslations.TITLE), headerBackTitle: tNav(NavigationTranslations.BACK) }} />
     </Stack>
   );
 }

--- a/apps/mobile/i18n/constants.ts
+++ b/apps/mobile/i18n/constants.ts
@@ -3,6 +3,7 @@ export enum NavigationTranslations {
   CHATS = 'navigation.chats',
   INSIGHTS = 'navigation.insights',
   ACCOUNT = 'navigation.account',
+  BACK = 'navigation.back',
 }
 
 export enum GreetingsTranslations {
@@ -67,6 +68,16 @@ export enum DangerTranslations {
   PAUSE_ACCOUNT_DESCRIPTION = 'danger.pause_account.description',
   DELETE_ACCOUNT_LABEL = 'danger.delete_account.label',
   DELETE_ACCOUNT_DESCRIPTION = 'danger.delete_account.description',
+}
+
+export enum AccountOverviewTranslations {
+  OPEN = 'overview.open',
+  LOGOUT = 'overview.logout',
+  APP_VERSION = 'overview.app_version',
+  ACCOUNT_DESCRIPTION = 'overview.account.description',
+  SECURITY_DESCRIPTION = 'overview.security.description',
+  PREFERENCES_DESCRIPTION = 'overview.preferences.description',
+  DANGER_DESCRIPTION = 'overview.danger.description',
 }
 
 export const NAMESPACES = {

--- a/apps/mobile/i18n/locales/en/account.json
+++ b/apps/mobile/i18n/locales/en/account.json
@@ -18,6 +18,15 @@
       "description": "Select your preferred language"
     }
   },
+  "overview": {
+    "open": "Open",
+    "logout": "Logout",
+    "app_version": "App version {{version}}",
+    "account": { "description": "Profile and identity settings" },
+    "security": { "description": "Review all security settings" },
+    "preferences": { "description": "Theme and sync options" },
+    "danger": { "description": "Sensitive destructive actions" }
+  },
   "danger": {
     "title": "Danger Zone",
     "delete_data": {

--- a/apps/mobile/i18n/locales/en/navigation.json
+++ b/apps/mobile/i18n/locales/en/navigation.json
@@ -3,6 +3,7 @@
     "home": "Home",
     "chats": "Chats",
     "insights": "Insights",
-    "account": "Account"
+    "account": "Account",
+    "back": "Back"
   }
 }

--- a/apps/mobile/i18n/locales/es/account.json
+++ b/apps/mobile/i18n/locales/es/account.json
@@ -18,6 +18,15 @@
       "description": "Seleccionar tu idioma preferido"
     }
   },
+  "overview": {
+    "open": "Abrir",
+    "logout": "Cerrar sesión",
+    "app_version": "Versión de la app {{version}}",
+    "account": { "description": "Configuración de perfil e identidad" },
+    "security": { "description": "Revisar todas las configuraciones de seguridad" },
+    "preferences": { "description": "Opciones de tema y sincronización" },
+    "danger": { "description": "Acciones destructivas sensibles" }
+  },
   "danger": {
     "title": "Zona de Peligro",
     "delete_data": {

--- a/apps/mobile/i18n/locales/es/navigation.json
+++ b/apps/mobile/i18n/locales/es/navigation.json
@@ -3,6 +3,7 @@
     "home": "Inicio",
     "chats": "Conversaciones",
     "insights": "Análisis",
-    "account": "Cuenta"
+    "account": "Cuenta",
+    "back": "Volver"
   }
 }

--- a/apps/mobile/views/account/index.tsx
+++ b/apps/mobile/views/account/index.tsx
@@ -2,30 +2,40 @@ import { Button } from '@/components/ui/Button';
 import { Link } from 'expo-router';
 import React from 'react';
 import { ScrollView, Separator, Text, XStack, YStack } from 'tamagui';
+import { useTranslation } from 'react-i18next';
+import {
+  NAMESPACES,
+  AccountTranslations,
+  AccountOverviewTranslations,
+} from '@/i18n/constants';
+import { APP_CONFIG } from '@/config/env.config';
+
+interface SettingsSectionItem {
+  label: string;
+  description?: string;
+  right?: React.ReactNode;
+  isDanger?: boolean;
+}
 
 interface SettingsSection {
   title: string;
-  items: {
-    label: string;
-    description?: string;
-    onPress?: () => void;
-    right?: React.ReactNode;
-    isDanger?: boolean;
-  }[];
+  items: SettingsSectionItem[];
 }
 
 export const AccountSettingsView = () => {
+  const { t } = useTranslation(NAMESPACES.ACCOUNT);
+
   const settingsSections: SettingsSection[] = [
     {
-      title: 'Account',
+      title: t(AccountTranslations.TITLE),
       items: [
         {
-          label: 'Open Account',
-          description: 'Profile and identity settings',
+          label: t('overview.open') + ' ' + t(AccountTranslations.TITLE),
+          description: t('overview.account.description'),
           right: (
             <Link href="/(tabs)/account/account" asChild>
               <Text color="$accentColor" fontWeight="700">
-                Open
+                {t(AccountOverviewTranslations.OPEN)}
               </Text>
             </Link>
           ),
@@ -33,16 +43,15 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: 'Security',
+      title: t('security.title'),
       items: [
         {
-          label: 'Open Security',
-          description: 'Review all security settings',
-          onPress: undefined,
+          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('security.title'),
+          description: t('overview.security.description'),
           right: (
             <Link href="/(tabs)/account/security" asChild>
               <Text color="$accentColor" fontWeight="700">
-                Open
+                {t(AccountOverviewTranslations.OPEN)}
               </Text>
             </Link>
           ),
@@ -50,15 +59,15 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: 'Preferences',
+      title: t('preferences.title'),
       items: [
         {
-          label: 'Open Preferences',
-          description: 'Theme and sync options',
+          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('preferences.title'),
+          description: t('overview.preferences.description'),
           right: (
             <Link href="/(tabs)/account/preferences" asChild>
               <Text color="$accentColor" fontWeight="700">
-                Open
+                {t(AccountOverviewTranslations.OPEN)}
               </Text>
             </Link>
           ),
@@ -66,16 +75,16 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: 'Danger Zone',
+      title: t('danger.title'),
       items: [
         {
-          label: 'Open Danger Zone',
-          description: 'Sensitive destructive actions',
+          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('danger.title'),
+          description: t('overview.danger.description'),
           isDanger: true,
           right: (
             <Link href="/(tabs)/account/danger" asChild>
               <Text color="$red10" fontWeight="700">
-                Open
+                {t(AccountOverviewTranslations.OPEN)}
               </Text>
             </Link>
           ),
@@ -120,8 +129,11 @@ export const AccountSettingsView = () => {
             </YStack>
           </YStack>
         ))}
+        <Text fontSize="$2" color="$color8">
+          {t(AccountOverviewTranslations.APP_VERSION, { version: APP_CONFIG.basics.version })}
+        </Text>
         <Separator marginVertical="$4" />
-        <Button variant="outline">Logout</Button>
+        <Button variant="outline">{t(AccountOverviewTranslations.LOGOUT)}</Button>
       </YStack>
     </ScrollView>
   );

--- a/apps/mobile/views/account/index.tsx
+++ b/apps/mobile/views/account/index.tsx
@@ -7,6 +7,9 @@ import {
   NAMESPACES,
   AccountTranslations,
   AccountOverviewTranslations,
+  SecurityTranslations,
+  PreferencesTranslations,
+  DangerTranslations,
 } from '@/i18n/constants';
 import { APP_CONFIG } from '@/config/env.config';
 
@@ -30,8 +33,8 @@ export const AccountSettingsView = () => {
       title: t(AccountTranslations.TITLE),
       items: [
         {
-          label: t('overview.open') + ' ' + t(AccountTranslations.TITLE),
-          description: t('overview.account.description'),
+          label: `${t(AccountOverviewTranslations.OPEN)} ${t(AccountTranslations.TITLE)}`,
+          description: t(AccountOverviewTranslations.ACCOUNT_DESCRIPTION),
           right: (
             <Link href="/(tabs)/account/account" asChild>
               <Text color="$accentColor" fontWeight="700">
@@ -43,11 +46,11 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: t('security.title'),
+      title: t(SecurityTranslations.TITLE),
       items: [
         {
-          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('security.title'),
-          description: t('overview.security.description'),
+          label: `${t(AccountOverviewTranslations.OPEN)} ${t(SecurityTranslations.TITLE)}`,
+          description: t(AccountOverviewTranslations.SECURITY_DESCRIPTION),
           right: (
             <Link href="/(tabs)/account/security" asChild>
               <Text color="$accentColor" fontWeight="700">
@@ -59,11 +62,11 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: t('preferences.title'),
+      title: t(PreferencesTranslations.TITLE),
       items: [
         {
-          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('preferences.title'),
-          description: t('overview.preferences.description'),
+          label: `${t(AccountOverviewTranslations.OPEN)} ${t(PreferencesTranslations.TITLE)}`,
+          description: t(AccountOverviewTranslations.PREFERENCES_DESCRIPTION),
           right: (
             <Link href="/(tabs)/account/preferences" asChild>
               <Text color="$accentColor" fontWeight="700">
@@ -75,11 +78,11 @@ export const AccountSettingsView = () => {
       ],
     },
     {
-      title: t('danger.title'),
+      title: t(DangerTranslations.TITLE),
       items: [
         {
-          label: t(AccountOverviewTranslations.OPEN) + ' ' + t('danger.title'),
-          description: t('overview.danger.description'),
+          label: `${t(AccountOverviewTranslations.OPEN)} ${t(DangerTranslations.TITLE)}`,
+          description: t(AccountOverviewTranslations.DANGER_DESCRIPTION),
           isDanger: true,
           right: (
             <Link href="/(tabs)/account/danger" asChild>


### PR DESCRIPTION
Translate account stack layout and settings overview to use i18n.

This PR internationalizes the account section by replacing hardcoded strings in `_layout.tsx` (stack headers and back button) and `AccountSettingsView` (section titles, descriptions, action labels, and app version) with i18n keys. New translation keys for navigation and account overview were added to `constants.ts` and the `en`/`es` locale files.

---
<a href="https://cursor.com/background-agent?bcId=bc-06e84b6b-2460-4914-b211-9d16dec37fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06e84b6b-2460-4914-b211-9d16dec37fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

